### PR TITLE
メニュー生成500エラーの修正: 廃止されたAIモデル名を現行モデルに更新

### DIFF
--- a/lib/ai-clients.ts
+++ b/lib/ai-clients.ts
@@ -49,6 +49,10 @@ export const AI_MODELS = {
           if (error.message.includes('insufficient_quota')) {
             throw new Error("OpenAI APIの使用量制限に達しました。アカウントの使用量を確認してください。");
           }
+          // モデル廃止・名称誤りを総称エラーに丸めない（原因特定を容易にする）
+          if (error.message.includes('model_not_found') || error.message.includes('does not exist')) {
+            throw new Error(`指定された OpenAI モデル（${AI_MODEL_CONFIGS.openai.model}）が見つかりません。モデルが廃止された可能性があります。`);
+          }
         }
         throw new Error("OpenAIからの応答の取得に失敗しました");
       }
@@ -106,6 +110,10 @@ ${prompt}
           if (error.message.includes('API_KEY_INVALID') || error.message.includes('Invalid API key')) {
             throw new Error("Google Gemini APIキーが無効です。正しいAPIキーを入力してください。");
           }
+          // モデル廃止・名称誤りを総称エラーに丸めない（原因特定を容易にする）
+          if (error.message.includes('not found') || error.message.includes('NOT_FOUND') || error.message.includes('404')) {
+            throw new Error(`指定された Gemini モデル（${AI_MODEL_CONFIGS.google.model}）が見つかりません。モデルが廃止された可能性があります。`);
+          }
           if (error.message.includes('QUOTA_EXCEEDED') || error.message.includes('quota exceeded')) {
             throw new Error("Google Gemini APIの使用量制限に達しました。しばらく待ってから再試行してください。");
           }
@@ -132,7 +140,6 @@ ${prompt}
           model: AI_MODEL_CONFIGS.anthropic.model,
           max_tokens: AI_MODEL_CONFIGS.anthropic.maxTokens,
           system: systemPrompt,
-          temperature: AI_MODEL_CONFIGS.anthropic.temperature,
           messages: [{ role: "user", content: fullPrompt }],
         });
         

--- a/lib/ai-config.ts
+++ b/lib/ai-config.ts
@@ -11,19 +11,21 @@ export const AI_MODEL_CONFIGS = {
     icon: "🤖",
   },
   google: {
-    model: "gemini-2.0-flash",
+    // gemini-2.0-flash は 2026-06-01 に提供終了。公式推奨の後継モデルを使用
+    model: "gemini-3.5-flash",
     temperature: 0.4,
-    displayName: "Google Gemini 2.0 Flash",
+    displayName: "Google Gemini 3.5 Flash",
     description: "基本無料で使用可能。高速・軽量。初回利用・学習目的やコスト効率を重視する場合に推奨。",
     apiKeyFormat: "AIza",
     apiKeyDescription: "Google Gemini APIキーを入力してください",
     icon: "🛡️",
   },
   anthropic: {
-    model: "claude-3-5-sonnet-20241022",
-    temperature: 0.5,
+    // claude-3-5-sonnet-20241022 は 2025-10-28 に提供終了。
+    // 後継の claude-sonnet-5 は temperature 指定を受け付けないため設定しない
+    model: "claude-sonnet-5",
     maxTokens: 4000,
-    displayName: "Anthropic Claude 3.5 Sonnet",
+    displayName: "Anthropic Claude Sonnet 5",
     description: "安全性と倫理性を重視。日常的な利用やバランスの取れた品質に最適。",
     apiKeyFormat: "sk-ant-",
     apiKeyDescription: "Anthropic Claude APIキーを入力してください（sk-ant-で始まる形式）",


### PR DESCRIPTION
## 問題

本番でメニュー生成が `/api/generate-menu` の 500 で失敗し、「Geminiからの応答の取得に失敗しました」が表示される。

## 原因

設定されていた AI モデルのうち2つがプロバイダ側で提供終了しており、API が 404 を返していた(2026-07-06 時点、各社公式ドキュメントで確認):

| プロバイダ | 旧設定 | 状態 | 変更後 |
|---|---|---|---|
| Google | `gemini-2.0-flash` | **2026-06-01 提供終了**(今回の直接原因) | `gemini-3.5-flash`(公式推奨の後継) |
| Anthropic | `claude-3-5-sonnet-20241022` | **2025-10-28 提供終了** | `claude-sonnet-5` |
| OpenAI | `gpt-4o` | 提供中 | 変更なし |

## 変更内容

- `lib/ai-config.ts`: モデル名と表示名を更新。claude-sonnet-5 は temperature 指定を 400 で拒否するため `temperature` 設定を削除
- `lib/ai-clients.ts`: Anthropic への temperature 送信を削除。Gemini / OpenAI の catch に「モデルが見つからない」分岐を追加(廃止モデルが原因のときに総称エラーへ丸めず原因を表示するため)

## 確認

- `npx tsc --noEmit` 新規エラーなし、`npm test` は main のベースライン(54成功/25失敗)から退行なし
- dev サーバーで /create が正常レンダリング(モデル選択の表示は `AI_MODEL_CONFIGS.displayName` に追従)
- **実際の生成は API キーが必要なため未確認です。マージ前に Gemini キーで1回生成をお試しください**

## 補足(今回のスコープ外)

- gpt-4o は動作しますが旧世代です(現行は GPT-5.x 系)。更新は挙動変化を伴うため見送り
- モデル名は約1年周期で廃止されるため、同じ障害は再発し得ます。エラーメッセージ改善で次回は原因が画面に出ます

🤖 Generated with [Claude Code](https://claude.com/claude-code)