### PR TITLE
日本語テキストが単語の途中で改行されるのを修正

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -13,7 +13,10 @@ export default function AboutPage() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold mb-3 gradient-text">水泳部練習メニュー作成アプリ</h1>
+        {/* break-keep は wbr の位置でしか折り返さないため、文言を変えるときは wbr の位置も見直すこと */}
+        <h1 className="text-3xl font-bold mb-3 gradient-text break-keep">
+          水泳部<wbr />練習メニュー<wbr />作成アプリ
+        </h1>
         <p className="text-muted-foreground break-phrase">AIを活用して効率的に練習メニューを作成・保存・再利用</p>
       </div>
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,7 +14,7 @@ export default function AboutPage() {
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold mb-3 gradient-text">水泳部練習メニュー作成アプリ</h1>
-        <p className="text-muted-foreground">AIを活用して効率的に練習メニューを作成・保存・再利用</p>
+        <p className="text-muted-foreground break-phrase">AIを活用して効率的に練習メニューを作成・保存・再利用</p>
       </div>
 
       {/* 概要（利用者向け） */}

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -11,7 +11,7 @@ export default function CreatePage() {
     <div className="container mx-auto px-4 py-12">
       <div className="flex flex-col items-center justify-center text-center mb-8">
         <h1 className="text-3xl font-bold tracking-tight mb-4">練習メニュー作成</h1>
-        <p className="text-lg text-muted-foreground max-w-3xl">
+        <p className="text-lg text-muted-foreground max-w-3xl break-phrase">
           以下のフォームに必要事項を入力して、AIによる練習メニューを生成しましょう。
           過去のメニューデータがアップロードされている場合は、それらを参考にしたメニューが生成されます。
         </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,6 +83,17 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* 日本語見出しを単語(文節)の途中で折り返さない。
+     word-break: auto-phrase は Chrome/Edge のみ対応で、非対応ブラウザでは無視され従来表示のまま */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    word-break: auto-phrase;
+    text-wrap: balance;
+  }
 }
 
 .wave-bg {
@@ -123,5 +134,9 @@
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+  /* 見出し以外(リード文・説明文など)を文節単位で折り返したい箇所に付与する */
+  .break-phrase {
+    word-break: auto-phrase;
   }
 }

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -15,7 +15,7 @@ export default function HelpPage() {
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold tracking-tight mb-4">AIヘルプセンター</h1>
-        <p className="text-muted-foreground text-lg">
+        <p className="text-muted-foreground text-lg break-phrase">
           AIの種類と使い分け、APIキーの設定方法について詳しく説明します
         </p>
       </div>

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -199,8 +199,8 @@ export default function HistoryPage() {
       ) : menus.length === 0 ? (
         <div role="status" className="rounded-lg border border-dashed px-6 py-12 text-center">
           <Waves className="mx-auto h-12 w-12 text-muted-foreground" aria-hidden="true" />
-          <p className="mt-4 text-lg font-medium">過去のメニューはありません</p>
-          <p className="mt-1 text-sm text-muted-foreground">
+          <p className="mt-4 text-lg font-medium break-phrase">過去のメニューはありません</p>
+          <p className="mt-1 text-sm text-muted-foreground break-phrase">
             メニューを作成すると、ここに履歴が表示されます。
           </p>
           <Button asChild className="mt-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">主要機能</h2>
-            <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-2xl mx-auto break-phrase">
               AIと過去のデータを活用して、質の高い練習メニューを短時間で作成
             </p>
           </div>
@@ -124,7 +124,7 @@ export default function Home() {
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">アプリの特徴</h2>
-            <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-2xl mx-auto break-phrase">
               最新のAI技術と使いやすいインターフェースで練習メニュー作成をサポート
             </p>
           </div>
@@ -174,7 +174,7 @@ export default function Home() {
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <h2 className="text-2xl md:text-3xl font-bold mb-4">初めての方へ</h2>
-            <p className="text-base md:text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed break-words">
+            <p className="text-base md:text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed break-phrase">
               AIの使い方やAPIキーの設定方法について詳しく説明しています
             </p>
           </div>
@@ -185,8 +185,8 @@ export default function Home() {
                 <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-6">
                   <HelpCircle className="w-8 h-8 text-primary" aria-hidden="true" />
                 </div>
-                <h3 className="text-xl md:text-2xl font-semibold mb-3 leading-tight break-words">AIの使い方とAPIキー設定</h3>
-                <p className="text-sm md:text-base text-muted-foreground mb-6 leading-relaxed break-words">
+                <h3 className="text-xl md:text-2xl font-semibold mb-3 leading-tight">AIの使い方とAPIキー設定</h3>
+                <p className="text-sm md:text-base text-muted-foreground mb-6 leading-relaxed break-phrase">
                   各種AIの特徴や使い分け、APIキーの取得方法について解説。
                   初めての方にも分かりやすくまとめています。
                 </p>
@@ -209,7 +209,7 @@ export default function Home() {
             <div className="absolute inset-0 bg-wave-pattern opacity-10 animate-wave motion-reduce:animate-none"></div>
             <div className="relative z-10 p-8 md:p-12 text-primary-foreground text-center">
               <h2 className="text-3xl md:text-4xl font-bold mb-6">効率的な練習メニュー作成を始めましょう</h2>
-              <p className="text-xl mb-8 text-primary-foreground/90 max-w-2xl mx-auto">
+              <p className="text-xl mb-8 text-primary-foreground/90 max-w-2xl mx-auto break-phrase">
                 AIと過去のデータを活用して、質の高い練習メニューを短時間で作成できます。 今すぐ試してみましょう。
               </p>
               <Button size="lg" variant="secondary" className="bg-background text-primary hover:bg-background/90" asChild>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,11 +18,14 @@ export default function Home() {
         <div className="absolute inset-0 bg-wave-pattern opacity-20 animate-wave motion-reduce:animate-none"></div>
         <div className="container relative z-10 mx-auto px-4">
           <div className="flex flex-col items-center justify-center text-center mb-12">
-            <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
-              <span className="gradient-text">水泳部練習メニュー作成</span>
+            {/* break-keep は wbr の位置でしか折り返さないため、文言を変えるときは wbr の位置も見直すこと */}
+            <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6 break-keep">
+              <span className="gradient-text">
+                水泳部<wbr />練習メニュー<wbr />作成
+              </span>
             </h1>
-            <p className="text-xl md:text-2xl text-muted-foreground max-w-3xl mb-8">
-              AIを活用して効率的に水泳部の練習メニューを作成するアプリケーション
+            <p className="text-xl md:text-2xl text-muted-foreground max-w-3xl mb-8 break-keep">
+              AIを<wbr />活用して<wbr />効率的に<wbr />水泳部の<wbr />練習メニューを<wbr />作成する<wbr />アプリケーション
             </p>
             <div className="flex flex-col sm:flex-row gap-4">
               <Button size="lg" asChild>
@@ -208,7 +211,9 @@ export default function Home() {
           <div className="relative max-w-4xl mx-auto rounded-lg overflow-hidden bg-primary">
             <div className="absolute inset-0 bg-wave-pattern opacity-10 animate-wave motion-reduce:animate-none"></div>
             <div className="relative z-10 p-8 md:p-12 text-primary-foreground text-center">
-              <h2 className="text-3xl md:text-4xl font-bold mb-6">効率的な練習メニュー作成を始めましょう</h2>
+              <h2 className="text-3xl md:text-4xl font-bold mb-6 break-keep">
+                効率的な<wbr />練習メニュー作成を<wbr />始めましょう
+              </h2>
               <p className="text-xl mb-8 text-primary-foreground/90 max-w-2xl mx-auto break-phrase">
                 AIと過去のデータを活用して、質の高い練習メニューを短時間で作成できます。 今すぐ試してみましょう。
               </p>

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -14,7 +14,7 @@ export default function UploadPage() {
     <div className="container mx-auto px-4 py-12">
       <div className="flex flex-col items-center justify-center text-center mb-8">
         <h1 className="text-3xl font-bold tracking-tight mb-4">過去メニュー管理</h1>
-        <p className="text-lg text-muted-foreground max-w-3xl">
+        <p className="text-lg text-muted-foreground max-w-3xl break-phrase">
           過去の練習メニューをCSVやPDFでアップロードし、メニュー生成時の参考データとして活用できます。
           アップロードされたデータはRAG（Retrieval-Augmented Generation）技術により、
           新しいメニュー生成時に関連性の高い情報として参照されます。

--- a/components/result-content.tsx
+++ b/components/result-content.tsx
@@ -131,7 +131,7 @@ export default function ResultContent() {
 
       <div className="flex flex-col items-center justify-center text-center mb-8">
         <h1 className="text-3xl font-bold tracking-tight mb-4">生成されたメニュー</h1>
-        <p className="text-lg text-muted-foreground max-w-3xl">
+        <p className="text-lg text-muted-foreground max-w-3xl break-phrase">
           AIによって生成された練習メニューです。 PDFやCSVでダウンロードすることができます。
         </p>
       </div>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-balance break-phrase text-2xl font-semibold leading-none tracking-tight",
       className
     )}
     {...props}
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("break-phrase text-sm text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/components/uploaded-files-list.tsx
+++ b/components/uploaded-files-list.tsx
@@ -168,7 +168,7 @@ export default function UploadedFilesList() {
               <AlertCircle className="h-8 w-8 text-primary" aria-hidden="true" />
             </div>
             <h3 className="text-lg font-medium">ファイルがありません</h3>
-            <p className="text-sm text-muted-foreground mt-2 max-w-xs">
+            <p className="text-sm text-muted-foreground mt-2 max-w-xs break-phrase">
               過去の練習メニューをアップロードして、AIによるメニュー生成の精度を向上させましょう
             </p>
           </div>


### PR DESCRIPTION
## 概要

画面上の日本語テキストが単語の途中(「メニュ／ー作成」「アプリケーショ／ン」など)で折り返される問題を修正しました。日本語は CSS を指定しないとどの文字間でも改行されるブラウザの標準挙動が原因で、これまで折り返しの制御がどこにも入っていませんでした。

## 変更内容

3段構えで対応しています。

1. **見出し全体への一括適用**(`app/globals.css`)
   `h1`〜`h6` に `word-break: auto-phrase`(文節単位の折り返し)と `text-wrap: balance`(行長の均等化)を適用。div 実装の `CardTitle` / `CardDescription` はセレクタで拾えないため、`components/ui/card.tsx` に直接クラスを追加しました。
2. **リード文・空状態メッセージへの個別付与**
   `.break-phrase` ユーティリティを定義し、トップページ・create・upload・about・help・履歴の空状態など目立つ短文ブロックに付与。単語の途中で折る方向に働く既存の `break-words` 3箇所は置き換えました。
3. **特に目立つ箇所は手動の改行ポイント**(トップページの h1・リード文・CTA 見出し、about の h1)
   `auto-phrase` は Chrome/Edge 119+ のみの対応(MDN browser-compat-data で確認。Safari は開発版のみ、Firefox 未対応)のため、`break-keep` + `<wbr>` の組み合わせで全ブラウザで文節位置だけで折り返すようにしています。

## 動作確認

- `npx tsc --noEmit`: 新規エラーなし(既存8件のみ)
- `npm test`: 60成功 / 19失敗のベースラインから退行なし
- dev サーバーで全8ルート 200、HTML に `<wbr>`(10箇所)・`break-phrase`、CSS に `word-break: auto-phrase` が出力されることを確認済み

## 確認のお願い

Chrome とスマホ幅(375px 程度)で、トップページの見出し・リード文が文節単位で折り返されることを確認してください。Safari では手動区切りを入れた箇所(トップ・about)以外は従来どおり途中で折れることがあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)